### PR TITLE
Cleanup, test file fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+*.userprefs

--- a/SVGKitBindings.TestProject/SVGKitBindings.TestProject.userprefs
+++ b/SVGKitBindings.TestProject/SVGKitBindings.TestProject.userprefs
@@ -1,9 +1,11 @@
 ﻿<Properties StartupItem="SVGKitBindings.TestProject/SVGKitBindings.TestProject.csproj">
-  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug|iPhoneSimulator" PreferredExecutionTarget="MonoDevelop.IPhone.IPhoneSimulatorTarget.IPhone5s.8.1" />
-  <MonoDevelop.Ide.Workbench>
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release|iPhone" PreferredExecutionTarget="MonoDevelop.IPhone.IPhoneDeviceTarget.Mike's iPhone 5s" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="SVGKitBindings.TestProject/MainViewController.cs">
     <Files>
-      <File FileName="SVGKitBindings.TestProject/MainViewController.cs" Line="1" Column="1" />
-      <File FileName="../SVGKitBindings/SVGKitBindings/obj/Debug/ios/SVGKitBindings/SVGKImage.g.cs" Line="1" Column="1" />
+      <File FileName="SVGKitBindings.TestProject/MainViewController.cs" Line="45" Column="2" />
+      <File FileName="../SVGKitBindings/SVGKitBindings/libSVGKit-iOS.1.2.0.linkwith.cs" Line="1" Column="1" />
+      <File FileName="../SVGKitBindings/SVGKitBindings/ApiDefinition.cs" Line="9" Column="1" />
+      <File FileName="SVGKitBindings.TestProject/Tester.svg" Line="1" Column="1" />
     </Files>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>

--- a/SVGKitBindings.TestProject/SVGKitBindings.TestProject/SVGKitBindings.TestProject.csproj
+++ b/SVGKitBindings.TestProject/SVGKitBindings.TestProject/SVGKitBindings.TestProject.csproj
@@ -111,7 +111,6 @@
   <ItemGroup>
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
-    <None Include="Tester.svg" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -134,5 +133,8 @@
       <Project>{10426354-DAB0-41E8-AD13-39AD55868C3E}</Project>
       <Name>SVGKitBindings</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Tester.svg" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Ensures Tester.svg is deployed on run. Also stops tracking *.userprefs IDE prefs in repo.
